### PR TITLE
Update valueChanged for strict parsing with format

### DIFF
--- a/aurelia-bootstrap-datetimepicker/src/abp-datetime-picker.js
+++ b/aurelia-bootstrap-datetimepicker/src/abp-datetime-picker.js
@@ -283,7 +283,7 @@ export class AbpDatetimePickerCustomElement {
   valueChanged(newValue, oldValue) {
     if (newValue !== oldValue && newValue) {
       if (moment(newValue, this._format, true).isValid()) {
-        this.model = moment(newValue).toDate();
+        this.model = moment(newValue, this._format, true).toDate();
       }
     }
   }


### PR DESCRIPTION
Was not working with 'DD/MM/YYYY hh:mm A' format. This change works well for me, but I have not tested it. But as I can see in line 285, it already takes care of that moment date to be valid. Then I think it will work for other use cases.