### PR TITLE
Fix Don't select first item when multiple is true

### DIFF
--- a/aurelia-bootstrap-select/src/abp-select.js
+++ b/aurelia-bootstrap-select/src/abp-select.js
@@ -383,7 +383,7 @@ export class AbpSelectCustomElement {
    */
   renderSelection(selection) {
     if (this.domElm) {
-      if (this.isEmptySelection(selection) && this.util.parseBool(this.emptyOnNull)) {
+      if (this.isEmptySelection(selection) && this.util.parseBool(this.emptyOnNull) && !this.multiple) {
         this.domElm.selectpicker('val', null);
       } else if (!this.isEmptySelection(selection)) {
         this.domElm.selectpicker('val', selection.index);
@@ -394,10 +394,10 @@ export class AbpSelectCustomElement {
   renderPreSelection() {
     let newValue = this._originalSelectedIndexes || this._originalSelectedObjects;
     let selection = this.findItems(this.collection, newValue, this.objectKey);
-    if (this.isEmptySelection(selection)) {
+    if (this.isEmptySelection(selection) && !this.util.parseBool(this.emptyOnNull) && !this.multiple) {
       this.selectedValue = (this.util.isObject(this.collection[0]) ? this.collection[0][this.objectKey] : this.collection[0]);
       this.selectedItem = this.collection[0];
-    } else {
+    } else if (!this.isEmptySelection(selection)) {
       this.selectedValue = selection.index;
       this.selectedItem = selection.item;
     }

--- a/aurelia-bootstrap-select/src/abp-select.js
+++ b/aurelia-bootstrap-select/src/abp-select.js
@@ -383,7 +383,7 @@ export class AbpSelectCustomElement {
    */
   renderSelection(selection) {
     if (this.domElm) {
-      if (this.isEmptySelection(selection) && this.util.parseBool(this.emptyOnNull) && !this.multiple) {
+      if (this.isEmptySelection(selection) && (this.util.parseBool(this.emptyOnNull) || this.multiple)) {
         this.domElm.selectpicker('val', null);
       } else if (!this.isEmptySelection(selection)) {
         this.domElm.selectpicker('val', selection.index);
@@ -394,7 +394,13 @@ export class AbpSelectCustomElement {
   renderPreSelection() {
     let newValue = this._originalSelectedIndexes || this._originalSelectedObjects;
     let selection = this.findItems(this.collection, newValue, this.objectKey);
-    if (this.isEmptySelection(selection) && !this.util.parseBool(this.emptyOnNull) && !this.multiple) {
+    if (this.isEmptySelection(selection) && (this.util.parseBool(this.emptyOnNull) || this.multiple)) {
+        if (Array.isArray(this.selectedValue))
+            this.selectedValue = [];
+        else
+            this.selectedValue = null;
+        this.selectedItem = null;
+    } else if (this.isEmptySelection(selection)) {
       this.selectedValue = (this.util.isObject(this.collection[0]) ? this.collection[0][this.objectKey] : this.collection[0]);
       this.selectedItem = this.collection[0];
     } else if (!this.isEmptySelection(selection)) {


### PR DESCRIPTION
When multipe is true on the select, the first item shouldn't be selected by default.