### PR TITLE
Fix order-insensitive array comparison

### DIFF
--- a/aurelia-bootstrap-select/src/util-service.js
+++ b/aurelia-bootstrap-select/src/util-service.js
@@ -10,11 +10,15 @@ export class UtilService {
     if (a === null || b === null) return false;
     if (a.length !== b.length) return false;
 
-    // If you don't care about the order of the elements inside
-    // the array, you should sort both arrays here.
-
-    for (let i = 0; i < a.length; ++i) {
-      if (a[i] !== b[i]) return false;
+    //return a.every(_a => b.includes(_a));
+    for (let i = 0; i < a.length; i++) {
+        let aExistsInb = false;
+        for (let j = 0; j < b.length && !aExistsInb; j++) {
+            if (a[i] == b[i])
+                aExistsInb = true;
+        }
+        if (!aExistsInb)
+            return false;
     }
     return true;
   }

--- a/aurelia-bootstrap-select/src/util-service.js
+++ b/aurelia-bootstrap-select/src/util-service.js
@@ -10,15 +10,16 @@ export class UtilService {
     if (a === null || b === null) return false;
     if (a.length !== b.length) return false;
 
-    //return a.every(_a => b.includes(_a));
     for (let i = 0; i < a.length; i++) {
-        let aExistsInb = false;
+      let aExistsInb = false;
         for (let j = 0; j < b.length && !aExistsInb; j++) {
-            if (a[i] == b[j])
-                aExistsInb = true;
+          if (a[i] === b[j]) {
+            aExistsInb = true;
+          }
         }
-        if (!aExistsInb)
-            return false;
+        if (!aExistsInb) {
+          return false;
+      }
     }
     return true;
   }

--- a/aurelia-bootstrap-select/src/util-service.js
+++ b/aurelia-bootstrap-select/src/util-service.js
@@ -14,7 +14,7 @@ export class UtilService {
     for (let i = 0; i < a.length; i++) {
         let aExistsInb = false;
         for (let j = 0; j < b.length && !aExistsInb; j++) {
-            if (a[i] == b[i])
+            if (a[i] == b[j])
                 aExistsInb = true;
         }
         if (!aExistsInb)

--- a/aurelia-bootstrap-select/src/util-service.js
+++ b/aurelia-bootstrap-select/src/util-service.js
@@ -12,13 +12,13 @@ export class UtilService {
 
     for (let i = 0; i < a.length; i++) {
       let aExistsInb = false;
-        for (let j = 0; j < b.length && !aExistsInb; j++) {
-          if (a[i] === b[j]) {
-            aExistsInb = true;
-          }
+      for (let j = 0; j < b.length && !aExistsInb; j++) {
+        if (a[i] === b[j]) {
+          aExistsInb = true;
         }
-        if (!aExistsInb) {
-          return false;
+      }
+      if (!aExistsInb) {
+        return false;
       }
     }
     return true;


### PR DESCRIPTION
When multiselect is true and "Select all" is clicked, there is an infinite loop where bootstrap-select returns a list, the list is set in abp-select that causes bootstrap-select to fire again, it returns the list to abp-select, but in a different order, etc. etc.  The commented out code that uses a.every and b.includes works in typescript.  I'm assuming you are using Babel, and I don't know if it will polyfill for old IE browsers, so I dropped back to plain old Javascript looping.