### PR TITLE
Resolve empty initialised value when using model.bind

### DIFF
--- a/aurelia-bootstrap-datetimepicker/src/abp-datetime-picker.js
+++ b/aurelia-bootstrap-datetimepicker/src/abp-datetime-picker.js
@@ -146,7 +146,7 @@ export class AbpDatetimePickerCustomElement {
         this.model = moment(value, this._format, true).toDate();
       }
       if (!this.value) {
-        this.value = moment(value, this._format, true);
+        this.value = moment(value, this._format, true).format(this._format);
       }
     }
   }


### PR DESCRIPTION
Binding a `model` but no `value` resulted in the `value` being initialised with a moment object instead of the expected formatted string, resulting in nothing appearing in the text box despite the date correctly bound behind the scenes. This change fixes this issue.